### PR TITLE
Support ipv6 traffic shaping

### DIFF
--- a/app/lib/netem_commands.js
+++ b/app/lib/netem_commands.js
@@ -45,6 +45,9 @@ exports.build = function (netemPort, operation) {
       commands.push({cmd: "sudo tc filter add dev "+iface+" parent "+
                           "ffff: protocol ip u32 match u32 0 0 flowid 1:1 "+
                           "action mirred egress redirect dev "+ifb_iface});
+      commands.push({cmd: "sudo tc filter add dev "+iface+" parent "+
+                          "ffff: protocol ipv6 u32 match u32 0 0 flowid 1:1 "+
+                          "action mirred egress redirect dev "+ifb_iface});
     }
 
     var netem_parent = "root";


### PR DESCRIPTION
By adding a filter for it on the same qdisc as we use for ipv4 traffic.

---

After this PR:
```
$ docker exec "$wemu" curl --connect-timeout 3 --request POST --header "Content-Type: application/json" --data-binary '{"ifname": "eth0", "enabled": true, "ratecontrol": true, "ratecontrol_rate": 300000, "queue_delay_ms": 2000, "delay": true, "delay_ms": 350.0, "delay_var": 0, "delay_corr": 0, "delay_dist": "paretonormal", "loss": true, "loss_pct": 0}' http://localhost/port/upload
# ...
$ docker exec "$wemu" curl --connect-timeout 3 --request POST --header "Content-Type: application/json" --data-binary '{"ifname": "eth1", "enabled": true, "ratecontrol": true, "ratecontrol_rate": 300000, "queue_delay_ms": 2000, "delay": true, "delay_ms": 350.0, "delay_var": 0, "delay_corr": 0, "delay_dist": "paretonormal", "loss": true, "loss_pct": 0}' http://localhost/port/download
# ...
$ docker exec "$client" ping -c 5 1.1.1.1
PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
64 bytes from 1.1.1.1: icmp_seq=2 ttl=51 time=802 ms
64 bytes from 1.1.1.1: icmp_seq=3 ttl=51 time=773 ms
64 bytes from 1.1.1.1: icmp_seq=4 ttl=51 time=748 ms
64 bytes from 1.1.1.1: icmp_seq=5 ttl=51 time=754 ms

--- 1.1.1.1 ping statistics ---
5 packets transmitted, 4 received, 20% packet loss, time 4019ms
rtt min/avg/max/mdev = 748.257/769.337/801.556/20.801 ms
```

Before this change:
```
$ docker exec "$wemu" curl --connect-timeout 3 --request POST --header "Content-Type: application/json" --data-binary '{"ifname": "eth0", "enabled": true, "ratecontrol": true, "ratecontrol_rate": 300000, "queue_delay_ms": 2000, "delay": true, "delay_ms": 350.0, "delay_var": 0, "delay_corr": 0, "delay_dist": "paretonormal", "loss": true, "loss_pct": 0}' http://localhost/port/upload
# ...
$ docker exec "$wemu" curl --connect-timeout 3 --request POST --header "Content-Type: application/json" --data-binary '{"ifname": "eth1", "enabled": true, "ratecontrol": true, "ratecontrol_rate": 300000, "queue_delay_ms": 2000, "delay": true, "delay_ms": 350.0, "delay_var": 0, "delay_corr": 0, "delay_dist": "paretonormal", "loss": true, "loss_pct": 0}' http://localhost/port/download
# ...
$ docker exec "$client" ping -c 5 1.1.1.1
PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
64 bytes from 1.1.1.1: icmp_seq=1 ttl=51 time=46.6 ms
64 bytes from 1.1.1.1: icmp_seq=2 ttl=51 time=386 ms
64 bytes from 1.1.1.1: icmp_seq=3 ttl=51 time=30.3 ms
64 bytes from 1.1.1.1: icmp_seq=4 ttl=51 time=23.6 ms
64 bytes from 1.1.1.1: icmp_seq=5 ttl=51 time=35.2 ms

--- 1.1.1.1 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 4006ms
rtt min/avg/max/mdev = 23.562/104.312/385.852/140.971 ms
```